### PR TITLE
Updated cc and ccx tools to support arm64.

### DIFF
--- a/config/compiler/BUILD.gn
+++ b/config/compiler/BUILD.gn
@@ -2194,15 +2194,15 @@ config("afdo") {
 # Full symbols.
 config("symbols") {
   if (is_win) {
+    cflags = []
     if (use_goma || is_clang) {
-      # Note that with VC++ this requires is_win_fastlink, enforced elsewhere.
-      cflags = [ "/Z7" ]  # Debug information in the .obj files.
-    } else {
-      if (is_clang) {
-        cflags = [ "" ]
-      } else {
-        cflags = [ "/Zi" ]  # Produce PDB file, no edit and continue.
+      # This check is added because Calng-Cl.exe doesn't emmit CodeView debug information for arm and arm64.
+      if (!(is_clang && current_os == "winuwp" && (current_cpu == "arm" || current_cpu == "arm64"))) {
+        # Note that with VC++ this requires is_win_fastlink, enforced elsewhere.
+        cflags = [ "/Z7" ]  # Debug information in the .obj files.
       }
+    } else {
+      cflags = [ "/Zi" ]  # Produce PDB file, no edit and continue.
     }
 
     if (is_win_fastlink && !use_lld) {

--- a/config/win/BUILD.gn
+++ b/config/win/BUILD.gn
@@ -282,10 +282,20 @@ config("runtime_library") {
       defines += [ "WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP" ]
     }
     cflags_cc += [
-      "/EHsc",
       "/std:c++17",
       "/Zc:__cplusplus",
     ]
+    
+    #TEMPORARY!!! Clang-cl.exe missing unwind support for Windows arm and arm64. This will generate errors in places where try/catch are used
+    if (is_clang && (current_cpu == "arm" || current_cpu == "arm64")) {
+      cflags_cc += [
+        "/EHs-c-",
+      ]
+    } else {
+      cflags_cc += [
+        "/EHsc"
+      ]
+    }
 
     # This warning is given because the linker cannot tell the difference
     # between consuming WinRT APIs versus authoring WinRT within static

--- a/toolchain/win/BUILD.gn
+++ b/toolchain/win/BUILD.gn
@@ -172,7 +172,9 @@ template("msvc_toolchain") {
         "$object_subdir/{{source_name_part}}.obj",
       ]
       if (target_name == "uwp_clang_arm" || target_name == "win_clang_arm") {
-        command = "$env_wrapper$cl /nologo /showIncludes ${clflags} $sys_include_flags{{defines}} {{include_dirs}} {{cflags}} {{cflags_c}} /c {{source}} /Fo{{output}} /Fd\"$pdbname\" --target=armv7-windows-msvc /D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE" 
+        command = "$env_wrapper$cl /nologo /showIncludes ${clflags} $sys_include_flags{{defines}} {{include_dirs}} {{cflags}} {{cflags_c}} /c {{source}} /Fo{{output}} /Fd\"$pdbname\" --target=arm-windows-msvc /D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE" 
+      } else if (target_name == "uwp_clang_arm64" || target_name == "win_clang_arm64") {
+        command = "$env_wrapper$cl /nologo /showIncludes ${clflags} $sys_include_flags{{defines}} {{include_dirs}} {{cflags}} {{cflags_c}} /c {{source}} /Fo{{output}} /Fd\"$pdbname\" --target=aarch64-windows-msvc  /DWindowsSDKDesktopARM64Support=1" 
       } else {
           rspfile = "{{output}}.rsp"
           command = "$env_wrapper$cl /nologo /showIncludes ${clflags} @$rspfile /c {{source}} /Fo{{output}} /Fd\"$pdbname\""
@@ -196,7 +198,9 @@ template("msvc_toolchain") {
       ]
       
       if (target_name == "uwp_clang_arm" || target_name == "win_clang_arm") {
-        command = "$env_wrapper$cl /nologo /showIncludes ${clflags} $sys_include_flags{{defines}} {{include_dirs}} {{cflags}} {{cflags_cc}} /c {{source}} /Fo{{output}} /Fd\"$pdbname\" --target=armv7-windows-msvc /D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE" 
+        command = "$env_wrapper$cl /nologo /showIncludes ${clflags} $sys_include_flags{{defines}} {{include_dirs}} {{cflags}} {{cflags_cc}} /c {{source}} /Fo{{output}} /Fd\"$pdbname\" --target=arm-windows-msvc /D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE" 
+      } else if (target_name == "uwp_clang_arm64" || target_name == "win_clang_arm64") {
+        command = "$env_wrapper$cl /nologo /showIncludes ${clflags} $sys_include_flags{{defines}} {{include_dirs}} {{cflags}} {{cflags_cc}} /c {{source}} /Fo{{output}} /Fd\"$pdbname\" --target=aarch64-windows-msvc /DWindowsSDKDesktopARM64Support=1" 
       } else {
         rspfile = "{{output}}.rsp"
         command = "$env_wrapper$cl /nologo /showIncludes ${clflags} @$rspfile /c {{source}} /Fo{{output}} /Fd\"$pdbname\""


### PR DESCRIPTION
/Z7 flag is removed for arm and arm64 when project is built with clang-cl
Temporary /EHs-c- is used for  arm and arm64 when project is built with clang-cl