### PR TITLE
Enable forcing `/std:c++17` via GN argument

### DIFF
--- a/config/win/BUILD.gn
+++ b/config/win/BUILD.gn
@@ -46,12 +46,27 @@ declare_args() {
   #  and with this switch, clang emits it like this:
   #    foo/bar.cc:12:34: error: something went wrong
   use_clang_diagnostics_format = false
+
+  # Enable C++17 even on Win32.
+  # For UWP, C++17 is always enabled because it is needed for C++/WinRT to
+  # compile the wrappers.
+  # This is needed to work around the fact that Abseil defines an incompatible
+  # absl::optional in pre-c++17 mode while std::optional is used in c++17 mode.
+  # So programs linking against webrtc.lib need to compile with the correct mode.
+  std_cpp17 = false
 }
 
 # This is included by reference in the //build/config/compiler config that
 # is applied to all targets. It is here to separate out the logic that is
 # Windows-only.
 config("compiler") {
+  configs = []
+  if (current_os == "winuwp") {
+    std_cpp17 = true
+  }
+  if (std_cpp17) {
+    configs += [ "//build/config/win:cpp17" ]
+  }
   if (current_cpu == "x86") {
     asmflags = [
       # When /safeseh is specified, the linker will only produce an image if it
@@ -281,10 +296,6 @@ config("runtime_library") {
     } else {
       defines += [ "WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP" ]
     }
-    cflags_cc += [
-      "/std:c++17",
-      "/Zc:__cplusplus",
-    ]
     
     #TEMPORARY!!! Clang-cl.exe missing unwind support for Windows arm and arm64. This will generate errors in places where try/catch are used
     if (is_clang && (current_cpu == "arm" || current_cpu == "arm64")) {


### PR DESCRIPTION
Use a new `std_cpp17` argument in Windows builds to enable forcing Win32
MSVC builds to use `/std:c++17`. This is already forced for UWP, but is
needed for Win32 if a module compiled with C++17 needs to link against
the `webrtc.lib` compiled from this repository. Otherwise the layout
mismatch between `absl::optional` (non-c++17) and `std::optional`
(c++17) produces a link error.